### PR TITLE
fix: enable image resizing in Quill editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ngx-monaco-editor-v2": "^16.0.1",
         "ngx-quill": "^22.1.0",
         "quill": "^1.3.7",
+        "quill-image-resize-module": "^3.0.0",
         "quill-mention": "^4.0.0",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
@@ -9239,8 +9240,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12123,6 +12123,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/quill-image-resize-module": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quill-image-resize-module/-/quill-image-resize-module-3.0.0.tgz",
+      "integrity": "sha512-1TZBnUxU/WIx5dPyVjQ9yN7C6mLZSp04HyWBEMqT320DIq4MW4JgzlOPDZX5ZpBM3bU6sacU4kTLUc8VgYQZYw==",
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "quill": "^1.2.2",
+        "raw-loader": "^0.5.1"
+      }
+    },
     "node_modules/quill-mention": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/quill-mention/-/quill-mention-4.0.0.tgz",
@@ -12176,6 +12186,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q=="
     },
     "node_modules/read-package-json": {
       "version": "6.0.4",
@@ -21865,8 +21880,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -23905,6 +23919,16 @@
         "fast-diff": "1.1.2"
       }
     },
+    "quill-image-resize-module": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quill-image-resize-module/-/quill-image-resize-module-3.0.0.tgz",
+      "integrity": "sha512-1TZBnUxU/WIx5dPyVjQ9yN7C6mLZSp04HyWBEMqT320DIq4MW4JgzlOPDZX5ZpBM3bU6sacU4kTLUc8VgYQZYw==",
+      "requires": {
+        "lodash": "^4.17.4",
+        "quill": "^1.2.2",
+        "raw-loader": "^0.5.1"
+      }
+    },
     "quill-mention": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/quill-mention/-/quill-mention-4.0.0.tgz",
@@ -23939,6 +23963,11 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
+    },
+    "raw-loader": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "integrity": "sha512-sf7oGoLuaYAScB4VGr0tzetsYlS8EJH6qnTCfQ/WVEa89hALQ4RQfCKt5xCyPQKPDUbVUAIP1QsxAwfAjlDp7Q=="
     },
     "read-package-json": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ngx-monaco-editor-v2": "^16.0.1",
     "ngx-quill": "^22.1.0",
     "quill": "^1.3.7",
+    "quill-image-resize-module": "^3.0.0",
     "quill-mention": "^4.0.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/projects/tots/html-field-form/package.json
+++ b/projects/tots/html-field-form/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@tots/html-field-form",
-  "version": "16.0.2",
+  "version": "16.0.3",
   "peerDependencies": {
     "@angular/common": "^16.0.0",
     "@angular/core": "^16.0.0",
     "ngx-quill": "^22.0.0",
     "quill": "^1.3.7",
+    "quill-image-resize-module": "^3.0.0",
     "@tots/form": "^16.0.0"
   },
   "dependencies": {

--- a/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.html
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.html
@@ -5,6 +5,7 @@
 ></tots-outer-label>
 
 <quill-editor
+	*ngIf="isImageResizeReady"
 	[modules]="modules"
 	[formControl]="input"
 	[styles]="{height:  heightEditor + 'px'}"

--- a/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { TotsBaseFieldComponent } from '@tots/form';
+import { ensureImageResizeRegistered } from './register-image-resize';
 
 @Component({
   selector: 'tots-quill-field',
@@ -10,8 +11,12 @@ export class QuillFieldComponent extends TotsBaseFieldComponent implements OnIni
 
   heightEditor = 250;
   theme?: string;
+  isImageResizeReady = false;
 
   modules = {
+    imageResize: {
+      modules: ['Resize', 'DisplaySize'],
+    },
     toolbar: [
       ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
       ['blockquote', 'code-block'],
@@ -39,6 +44,9 @@ export class QuillFieldComponent extends TotsBaseFieldComponent implements OnIni
   override ngOnInit(): void {
     super.ngOnInit();
     this.loadConfig();
+    ensureImageResizeRegistered().then(() => {
+      this.isImageResizeReady = true;
+    });
   }
 
   editorCreated(quillInstance: any) {

--- a/projects/tots/html-field-form/src/lib/fields/quill-field/quill-image-resize-module.d.ts
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/quill-image-resize-module.d.ts
@@ -1,0 +1,1 @@
+declare module 'quill-image-resize-module';

--- a/projects/tots/html-field-form/src/lib/fields/quill-field/register-image-resize.ts
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/register-image-resize.ts
@@ -1,0 +1,36 @@
+/// <reference path="./quill-image-resize-module.d.ts" />
+import Quill from 'quill';
+
+// Depending on how the consumer's bundler resolves this CommonJS
+// package, the real ImageResize class can end up nested behind one or
+// more `.default` layers. Walk them until we find the constructor.
+function unwrapImageResizeCtor(mod: any): any {
+  while (mod && typeof mod !== 'function' && 'default' in mod) {
+    mod = mod.default;
+  }
+  return mod;
+}
+
+let imageResizeReady: Promise<void> | null = null;
+
+// quill-image-resize-module's Toolbar submodule reads
+// `window.Quill.imports.parchment` as soon as it's loaded, since it
+// assumes Quill is loaded as a global (e.g. via a <script> tag).
+//
+// A static `import` of that package would get hoisted above this
+// file's own code once a bundler flattens everything into one module
+// (e.g. an FESM bundle) — ES module imports are always fully resolved
+// before any local top-level statement runs, so `window.Quill = Quill`
+// would end up executing too late no matter where it's written.
+//
+// A dynamic `import()` isn't subject to that hoisting: it runs exactly
+// where it's called, so we can guarantee `window.Quill` is set first.
+export function ensureImageResizeRegistered(): Promise<void> {
+  if (!imageResizeReady) {
+    (window as any).Quill = Quill;
+    imageResizeReady = import('quill-image-resize-module').then((mod) => {
+      Quill.register('modules/imageResize', unwrapImageResizeCtor(mod));
+    });
+  }
+  return imageResizeReady;
+}


### PR DESCRIPTION
- Las imágenes insertadas en el editor Quill (`QuillFieldComponent`) no se podían redimensionar — no había ningún módulo de resize configurado - (https://app.clickup.com/t/31625254/86bb4anmg).
- Se agrega `quill-image-resize-module` como peerDependency y se registra mediante `ensureImageResizeRegistered()`.
- Se usa `import()` dinámico en vez de estático: `quill-image-resize-module` lee `window.Quill.imports.parchment` al cargar, pero un import estático se "sube" por encima de cualquier código local una vez que todo se combina en el bundle FESM, así que `window.Quill` nunca quedaría asignado a tiempo. El `import()` dinámico se ejecuta exactamente donde se llama, evitando ese problema.
- El editor ahora espera (`*ngIf="isImageResizeReady"`) a que termine el registro (ahora asíncrono) antes de renderizarse.
- Bump de versión a `16.0.3`.

## Plan de pruebas
- [ ] `npm install` compila sin errores
- [ ] Insertar una imagen en el editor y confirmar que aparecen los controladores de resize al hacer clic sobre ella
- [ ] Verificar que el contenido con imagen se guarda y recarga correctamente