### PR TITLE
fix: enable image resizing in Quill editor (Quill 2 / v20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "parchment": "^3.0.0",
         "quill": "^2.0.3",
         "quill-mention": "^6.1.1",
+        "quill-resize-image": "^1.0.11",
         "rxjs": "~7.5.0",
         "tslib": "^2.8.0",
         "zone.js": "~0.15.0"
@@ -12323,6 +12324,11 @@
       "dependencies": {
         "quill": "^2.0.2"
       }
+    },
+    "node_modules/quill-resize-image": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/quill-resize-image/-/quill-resize-image-1.0.11.tgz",
+      "integrity": "sha512-Pc9lwHZb5lrUs5jS7AqT2jFZUddirEARrrmBj2HrFSjAR4Qrtl9HbXMSog29dJxHoUmlnVlQXghqaz9vDNLJwg=="
     },
     "node_modules/quill/node_modules/eventemitter3": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "parchment": "^3.0.0",
     "quill": "^2.0.3",
     "quill-mention": "^6.1.1",
+    "quill-resize-image": "^1.0.11",
     "rxjs": "~7.5.0",
     "tslib": "^2.8.0",
     "zone.js": "~0.15.0"

--- a/projects/tots/html-field-form/package.json
+++ b/projects/tots/html-field-form/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@tots/html-field-form",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "peerDependencies": {
     "@angular/common": "^20.3.0",
     "@angular/core": "^20.3.0",
     "ngx-quill": "^28.0.1",
     "quill": "^2.0.3",
+    "quill-resize-image": "^1.0.11",
     "@tots/form": "^20.0.0"
   },
   "dependencies": {

--- a/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
@@ -1,5 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { TotsBaseFieldComponent } from '@tots/form';
+import Quill from 'quill';
+import QuillResizeImage from 'quill-resize-image';
+
+// Unlike quill-image-resize-module (Quill 1.x), quill-resize-image
+// receives the Quill instance directly as a constructor argument and
+// doesn't rely on a global `window.Quill`, so a plain static import
+// and registration is safe here.
+Quill.register('modules/resize', QuillResizeImage);
 
 @Component({
   selector: 'tots-quill-field',
@@ -13,6 +21,7 @@ export class QuillFieldComponent extends TotsBaseFieldComponent implements OnIni
 	protected theme = "";
 
   modules = {
+    resize: {},
     toolbar: [
       ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
       ['blockquote', 'code-block'],


### PR DESCRIPTION
- Las imágenes insertadas en el editor Quill (`QuillFieldComponent`) no se podían redimensionar — no había ningún módulo de resize configurado - (https://app.clickup.com/t/31625254/86bb4anmg).
- Se agrega `quill-resize-image` como peerDependency y se registra con `Quill.register('modules/resize', QuillResizeImage)`.
- A diferencia del fix de `v16m` (Quill 1.x, con `quill-image-resize-module`), aquí no hace falta `import()` dinámico ni esperar de forma asíncrona: `quill-resize-image` es compatible con Quill 2 y recibe la instancia de Quill directo como parámetro del constructor, sin depender de `window.Quill`. El registro es un import estático normal.
- Bump de versión a `20.0.1`.

## Plan de pruebas
- [ ] `npm install` compila sin errores
- [ ] Insertar una imagen en el editor y confirmar que aparece el handler de resize + la toolbar de tamaño/alineación al hacer clic sobre ella
- [ ] Verificar que el contenido con imagen se guarda y recarga correctamente
