### PR TITLE
fix: keep resize overlay in sync with editor scroll

### DIFF
--- a/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
+++ b/projects/tots/html-field-form/src/lib/fields/quill-field/quill-field.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { TotsBaseFieldComponent } from '@tots/form';
+import { Component, Inject, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { TOTS_FORM_DEFAULT_CONFIG, TotsBaseFieldComponent, TotsFormDefaultConfig } from '@tots/form';
 import { ensureImageResizeRegistered } from './register-image-resize';
 
 @Component({
@@ -7,11 +7,70 @@ import { ensureImageResizeRegistered } from './register-image-resize';
   templateUrl: './quill-field.component.html',
   styleUrls: ['./quill-field.component.scss']
 })
-export class QuillFieldComponent extends TotsBaseFieldComponent implements OnInit {
+export class QuillFieldComponent extends TotsBaseFieldComponent implements OnInit, OnDestroy {
 
   heightEditor = 250;
   theme?: string;
   isImageResizeReady = false;
+
+  // quill-image-resize-module never repositions on scroll/resize, only on
+  // click/drag. We attach on window's capture phase so it still catches
+  // scroll events from any ancestor, even non-bubbling ones.
+  protected imageResizeModule: any;
+
+  // The overlay lives outside .ql-editor, so its own internal scroll
+  // (fixed height, see heightEditor) never clips it — it must be hidden
+  // manually once the image scrolls out of the editor's visible area.
+  protected editorRoot: HTMLElement | null = null;
+
+  protected repositionImageOverlay = () => {
+    const module = this.imageResizeModule;
+    module?.repositionElements?.();
+
+    const overlay = module?.overlay;
+    const img = module?.img;
+    if (!overlay || !img || !this.editorRoot) {
+      return;
+    }
+
+    // Small tolerance so the image can clip slightly before the overlay
+    // disappears, instead of vanishing at the very first pixel.
+    const tolerance = 24;
+    const editorRect = this.editorRoot.getBoundingClientRect();
+    const imgRect = img.getBoundingClientRect();
+    const isVisible = imgRect.top >= editorRect.top - tolerance
+      && imgRect.bottom <= editorRect.bottom + tolerance
+      && imgRect.left >= editorRect.left - tolerance
+      && imgRect.right <= editorRect.right + tolerance;
+
+    overlay.style.display = isVisible ? '' : 'none';
+  };
+
+  // The overlay has no pointer-events set, so it swallows clicks/scroll
+  // meant for the editor underneath. Let it pass through; only the
+  // resize handles/label (its children) need to stay interactive.
+  private allowOverlayPointerEventsToPassThrough(module: any): void {
+    const originalShow = module?.show?.bind(module);
+    if (!originalShow) {
+      return;
+    }
+    module.show = (img: any) => {
+      originalShow(img);
+      if (module.overlay) {
+        module.overlay.style.pointerEvents = 'none';
+        Array.from(module.overlay.children as HTMLCollection).forEach((child) => {
+          (child as HTMLElement).style.pointerEvents = 'auto';
+        });
+      }
+    };
+  }
+
+  constructor(
+    @Inject(TOTS_FORM_DEFAULT_CONFIG) totsFormDefaultConfig: TotsFormDefaultConfig,
+    protected ngZone: NgZone
+  ) {
+    super(totsFormDefaultConfig);
+  }
 
   modules = {
     imageResize: {
@@ -50,13 +109,36 @@ export class QuillFieldComponent extends TotsBaseFieldComponent implements OnIni
   }
 
   editorCreated(quillInstance: any) {
+    this.imageResizeModule = quillInstance.getModule('imageResize');
+    this.editorRoot = quillInstance.root;
+    this.allowOverlayPointerEventsToPassThrough(this.imageResizeModule);
+    this.ngZone.runOutsideAngular(() => {
+      window.addEventListener('scroll', this.repositionImageOverlay, true);
+      window.addEventListener('resize', this.repositionImageOverlay);
+
+      // The module's click handler no-ops on a click that re-selects an
+      // already-selected image, so a stale hidden overlay never gets a
+      // chance to reappear. Force our own visibility check on every
+      // image click, regardless of what the module's handler did.
+      quillInstance.root.addEventListener('click', (evt: MouseEvent) => {
+        if ((evt.target as HTMLElement)?.tagName === 'IMG') {
+          this.repositionImageOverlay();
+        }
+      });
+    });
+
     // Verify if exist file Service
     if(this.field.extra.fileService == undefined){
       return;
     }
-    
+
     // Config Upload image
     this.loadConfigUploadImages(quillInstance);
+  }
+
+  ngOnDestroy(): void {
+    window.removeEventListener('scroll', this.repositionImageOverlay, true);
+    window.removeEventListener('resize', this.repositionImageOverlay);
   }
 
   loadConfigUploadImages(quillInstance: any) {


### PR DESCRIPTION
 ## Problema

Al seleccionar una imagen en un campo de texto enriquecido (Quill) y hacer scroll,
el recuadro de resize (borde punteado + manijas) quedaba "flotando" sobre otro
contenido de la página en vez de seguir a la imagen. Además, a veces el scroll se
trababa cerca de la imagen, y otras veces había que hacer clic varias veces para
que el recuadro volviera a aparecer.

## Causa
- El overlay se agrega fuera de `.ql-editor` (en `.ql-container`), así que el
  scroll interno del propio editor (altura fija) no lo recorta: cuando la imagen
  salía del área visible, el overlay se quedaba dibujado en su última posición.
- El overlay no tenía `pointer-events` definido, por lo que capturaba clics y
  scroll destinados al editor de abajo.
- El manejador de clic del módulo no hace nada si la imagen ya estaba
  "seleccionada" internamente, así que un overlay que había quedado escondido
  por scroll no volvía a mostrarse con un solo clic.

## Solución
- Se oculta/muestra el overlay en cada scroll según si la imagen sigue dentro
  del área visible del editor (con un margen de tolerancia).
- El overlay deja pasar clics/scroll (`pointer-events: none`), y solo las
  manijas de resize quedan interactivas.
- Se fuerza una revisión de visibilidad en cada clic sobre una imagen,
  independientemente de si el módulo la consideraba ya seleccionada.